### PR TITLE
Avoid unnecessary re-renders

### DIFF
--- a/src/editor.js
+++ b/src/editor.js
@@ -19,12 +19,12 @@ export default class ReactMediumEditor extends React.Component {
   }
 
   componentDidMount() {
-    const dom = ReactDOM.findDOMNode(this);
+    this.dom = ReactDOM.findDOMNode(this);
 
-    this.medium = new MediumEditor(dom, this.props.options);
+    this.medium = new MediumEditor(this.dom, this.props.options);
     this.medium.subscribe('editableInput', e => {
       this._updated = true;
-      this.change(dom.innerHTML);
+      this.change(this.dom.innerHTML);
     });
   }
 
@@ -34,6 +34,10 @@ export default class ReactMediumEditor extends React.Component {
 
   componentWillUnmount() {
     this.medium.destroy();
+  }
+
+  shouldComponentUpdate(nextProps, nextState) {
+    return nextProps.text !== this.dom.innerHTML;
   }
 
   componentWillReceiveProps(nextProps) {


### PR DESCRIPTION
This update avoids unnecessary re-renders when the current content of the editor is set again as it's html prop. That can happen when a change propagates through a parent component.

Please take note that this is not only a performance issue, but it also throws the cursor position off if it's at the end of a line.